### PR TITLE
Added query string multi parsing

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -13,6 +13,7 @@ import type {
 	IRequestOptions,
 	IHttpRequestMethods,
 	ICredentialDataDecryptedObject,
+	GenericValue,
 } from 'n8n-workflow';
 import {
 	BINARY_ENCODING,
@@ -384,6 +385,20 @@ export class HttpRequestV3 implements INodeType {
 					});
 				}
 
+				const parametersToKeyValueAccumulate = async (
+					accumulator: IDataObject,
+					cur: { name: string; value: string; parameterType?: string; inputDataFieldName?: string },
+				) => {
+					if (accumulator[cur.name] && typeof accumulator[cur.name] === 'string') {
+						accumulator[cur.name] = [accumulator[cur.name], cur.value];
+					} else if (accumulator[cur.name]) {
+						(accumulator[cur.name] as GenericValue[])?.push(cur.value);
+					} else {
+						accumulator[cur.name] = cur.value;
+					}
+					return accumulator;
+				};
+
 				const parametersToKeyValue = async (
 					accumulator: { [key: string]: any },
 					cur: { name: string; value: string; parameterType?: string; inputDataFieldName?: string },
@@ -487,7 +502,7 @@ export class HttpRequestV3 implements INodeType {
 				// Get parameters defined in the UI
 				if (sendQuery && queryParameters) {
 					if (specifyQuery === 'keypair') {
-						requestOptions.qs = await reduceAsync(queryParameters, parametersToKeyValue);
+						requestOptions.qs = await reduceAsync(queryParameters, parametersToKeyValueAccumulate);
 					} else if (specifyQuery === 'json') {
 						// query is specified using JSON
 						try {

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -13,7 +13,6 @@ import type {
 	IRequestOptions,
 	IHttpRequestMethods,
 	ICredentialDataDecryptedObject,
-	GenericValue,
 } from 'n8n-workflow';
 import {
 	BINARY_ENCODING,
@@ -385,16 +384,19 @@ export class HttpRequestV3 implements INodeType {
 					});
 				}
 
-				const parametersToKeyValueAccumulate = async (
+				const parametersToKeyValueQs = async (
 					accumulator: IDataObject,
 					cur: { name: string; value: string; parameterType?: string; inputDataFieldName?: string },
 				) => {
-					if (accumulator[cur.name] && typeof accumulator[cur.name] === 'string') {
-						accumulator[cur.name] = [accumulator[cur.name], cur.value];
-					} else if (accumulator[cur.name]) {
-						(accumulator[cur.name] as GenericValue[])?.push(cur.value);
-					} else {
+					if (!cur.name) return accumulator; // ignore blank names
+					const prev = accumulator[cur.name];
+
+					if (prev === undefined) {
 						accumulator[cur.name] = cur.value;
+					} else if (Array.isArray(prev)) {
+						(prev as string[]).push(cur.value);
+					} else {
+						accumulator[cur.name] = [String(prev), cur.value];
 					}
 					return accumulator;
 				};
@@ -502,7 +504,8 @@ export class HttpRequestV3 implements INodeType {
 				// Get parameters defined in the UI
 				if (sendQuery && queryParameters) {
 					if (specifyQuery === 'keypair') {
-						requestOptions.qs = await reduceAsync(queryParameters, parametersToKeyValueAccumulate);
+						const filtered = queryParameters.filter((q) => q.name && q.name.trim().length > 0);
+						requestOptions.qs = await reduceAsync(filtered, parametersToKeyValueQs);
 					} else if (specifyQuery === 'json') {
 						// query is specified using JSON
 						try {


### PR DESCRIPTION
## Summary
The PR fixes the HTTP Request Node and it lets it send multiple query params with the same name


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP Request (v3): Query string generation for "Specify Query: Key Pair" now consistently accumulates multiple values per key (including repeated keys and arrays), filters out empty parameter names, and applies the correct behavior across all execution paths so parameters are neither lost nor misaggregated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->